### PR TITLE
feat: Remove the need for `Burner`

### DIFF
--- a/contracts/src/AxelarGateway.sol
+++ b/contracts/src/AxelarGateway.sol
@@ -5,7 +5,6 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IAxelarGateway } from './interfaces/IAxelarGateway.sol';
 
 import { BurnableMintableCappedERC20 } from './BurnableMintableCappedERC20.sol';
-import { Burner } from './Burner.sol';
 import { AdminMultisigBase } from './AdminMultisigBase.sol';
 
 abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
@@ -155,7 +154,7 @@ abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         address tokenAddress = tokenAddresses(symbol);
         require(tokenAddress != address(0), 'TOKEN_NOT_EXIST');
 
-        new Burner{ salt: salt }(tokenAddress, salt);
+        BurnableMintableCappedERC20(tokenAddress).burn(salt);
     }
 
     /********************\

--- a/contracts/test/AxelarGatewayMultisig.js
+++ b/contracts/test/AxelarGatewayMultisig.js
@@ -403,6 +403,9 @@ describe('AxelarGatewayMultisig', () => {
           keccak256(burnerInitCode),
         );
 
+        // This is simpler.
+        // const burnerAddress = await tokenContract.depositAddress(salt);
+
         const burnAmount = amount / 2;
 
         return tokenContract
@@ -478,6 +481,9 @@ describe('AxelarGatewayMultisig', () => {
           salt,
           keccak256(burnerInitCode),
         );
+
+        // This is simpler.
+        // const burnerAddress = await tokenContract.depositAddress(salt);
 
         const burnAmount = amount / 2;
 
@@ -655,6 +661,9 @@ describe('AxelarGatewayMultisig', () => {
               keccak256(burnerInitCode),
             );
 
+            // This is simpler.
+            // const burnerAddress = await tokenContract.depositAddress(salt);
+
             await tokenContract.transfer(burnerAddress, amount);
             const input = await getSignedMultisigExecuteInput(
               data,
@@ -810,6 +819,9 @@ describe('AxelarGatewayMultisig', () => {
               salt,
               keccak256(burnerInitCode),
             );
+
+            // This is simpler.
+            // const burnerAddress = await tokenContract.depositAddress(salt);
 
             await tokenContract.transfer(burnerAddress, amount);
             const input = await getSignedMultisigExecuteInput(

--- a/contracts/test/AxelarGatewaySinglesig.js
+++ b/contracts/test/AxelarGatewaySinglesig.js
@@ -833,6 +833,9 @@ describe('AxelarGatewaySingleSig', () => {
           keccak256(burnerInitCode),
         );
 
+        // This is simpler.
+        // const burnerAddress = await tokenContract.depositAddress(salt);
+
         const burnAmount = amount / 2;
 
         return tokenContract
@@ -904,6 +907,9 @@ describe('AxelarGatewaySingleSig', () => {
           salt,
           keccak256(burnerInitCode),
         );
+
+        // This is simpler.
+        // const burnerAddress = await tokenContract.depositAddress(salt);
 
         const burnAmount = amount / 2;
 


### PR DESCRIPTION
No `Burner` contract needed (so much cheaper burning), and token contract owners cannot burn tokens that are not in specific "deposit addresses".

Burner contrat code still needed for the same of not creating breaking changes in `axelar-core`.

Left comments on how deposit addresses can be made globally consistent for any salt (all chains, all tokens).