### PR TITLE
feature: github action for publishing bytecode

### DIFF
--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -29,5 +29,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: Bytecode-${GITHUB_REF#refs/tags/}
+          name: "Bytecode-${GITHUB_REF#refs/tags/}"
           path: build/

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -1,6 +1,7 @@
 name: Publish Compiled Bytecode
 
 on:
+  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -29,5 +29,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: Bytecode
+          name: Bytecode-${GITHUB_REF#refs/tags/}
           path: build/

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  publish-bytecode:
     strategy:
       matrix:
         node-version:

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -1,7 +1,6 @@
 name: Publish Compiled Bytecode
 
 on:
-  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -1,0 +1,34 @@
+name: Publish Compiled Bytecode
+
+on:
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        node-version:
+          - 14.x
+        os:
+          - ubuntu-18.04
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Bytecode
+          path: build/

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -30,5 +30,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: Upload Bytecode
+          name: Bytecode
           path: build/

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -1,12 +1,11 @@
 name: Publish Compiled Bytecode
 
 on:
-  pull_request:
   release:
     types: [published]
 
 jobs:
-  test:
+  publish:
     strategy:
       matrix:
         node-version:
@@ -30,5 +29,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: Bytecode
+          name: Upload Bytecode
           path: build/

--- a/.github/workflows/publish-bytecode.yaml
+++ b/.github/workflows/publish-bytecode.yaml
@@ -27,7 +27,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Get the tag
+        id: release_tag
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
       - uses: actions/upload-artifact@v2
         with:
-          name: "Bytecode-${GITHUB_REF#refs/tags/}"
+          name: Bytecode-${{ steps.release_tag.outputs.VERSION }}
           path: build/


### PR DESCRIPTION
Adding a github action to publish compiled bytecode as an artifact

You can see result of this action as `Bytecode.zip` in Artifacts section here
https://github.com/axelarnetwork/solidity-cgp-gateway/actions/runs/1683751224

