### PR TITLE
feature(AxelarGateway): prepare for future refund compatibility

### DIFF
--- a/src/Absorber.sol
+++ b/src/Absorber.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IERC20 } from './interfaces/IERC20.sol';
 
 contract Absorber {
-    constructor(address tokenAddress) {
+    constructor(address tokenAddress, address /* refundAddress */) {
         IERC20(tokenAddress).transfer(msg.sender, IERC20(tokenAddress).balanceOf(address(this)));
 
         selfdestruct(payable(address(0)));

--- a/src/Absorber.sol
+++ b/src/Absorber.sol
@@ -7,8 +7,8 @@ import { IERC20 } from './interfaces/IERC20.sol';
 contract Absorber {
     constructor(address /* refundAddress */) {}
 
-    function transferAndDestruct(address tokenAddress) external {
-        IERC20(tokenAddress).transfer(msg.sender, IERC20(tokenAddress).balanceOf(address(this)));
+    function transferAndDestruct(address tokenAddress, address recipient) external {
+        IERC20(tokenAddress).transfer(recipient, IERC20(tokenAddress).balanceOf(address(this)));
 
         selfdestruct(payable(address(0)));
     }

--- a/src/Absorber.sol
+++ b/src/Absorber.sol
@@ -5,7 +5,9 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IERC20 } from './interfaces/IERC20.sol';
 
 contract Absorber {
-    constructor(address tokenAddress, address /* refundAddress */) {
+    constructor(address /* refundAddress */) {}
+
+    function transferAndDestruct(address tokenAddress) external {
         IERC20(tokenAddress).transfer(msg.sender, IERC20(tokenAddress).balanceOf(address(this)));
 
         selfdestruct(payable(address(0)));

--- a/src/AxelarGateway.sol
+++ b/src/AxelarGateway.sol
@@ -161,7 +161,7 @@ abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         require(tokenAddress != address(0), 'TOKEN_NOT_EXIST');
 
         if (_isTokenExternal(symbol)) {
-            new Absorber{ salt: salt }(address(0x0)).transferAndDestruct(tokenAddress);
+            new Absorber{ salt: salt }(address(0x0)).transferAndDestruct(tokenAddress, address(this));
         } else {
             BurnableMintableCappedERC20(tokenAddress).burn(salt);
         }

--- a/src/AxelarGateway.sol
+++ b/src/AxelarGateway.sol
@@ -161,7 +161,7 @@ abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         require(tokenAddress != address(0), 'TOKEN_NOT_EXIST');
 
         if (_isTokenExternal(symbol)) {
-            new Absorber{ salt: salt }(tokenAddress);
+            new Absorber{ salt: salt }(tokenAddress, address(0x0));
         } else {
             BurnableMintableCappedERC20(tokenAddress).burn(salt);
         }

--- a/src/AxelarGateway.sol
+++ b/src/AxelarGateway.sol
@@ -161,7 +161,7 @@ abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         require(tokenAddress != address(0), 'TOKEN_NOT_EXIST');
 
         if (_isTokenExternal(symbol)) {
-            new Absorber{ salt: salt }(tokenAddress, address(0x0));
+            new Absorber{ salt: salt }(address(0x0)).transferAndDestruct(tokenAddress);
         } else {
             BurnableMintableCappedERC20(tokenAddress).burn(salt);
         }


### PR DESCRIPTION
This PR is a suggestion for changing `Absorber` contract so we can refund support in future without breaking changes to ERC20 linked address generation