### PR TITLE
feat: upgrade verifies codehash

### DIFF
--- a/src/AdminMultisigBase.sol
+++ b/src/AdminMultisigBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { EternalStorage } from './EternalStorage.sol';
 

--- a/src/AxelarGateway.sol
+++ b/src/AxelarGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IAxelarGateway } from './interfaces/IAxelarGateway.sol';
 import { IERC20 } from './interfaces/IERC20.sol';
@@ -95,7 +95,13 @@ abstract contract AxelarGateway is IAxelarGateway, AdminMultisigBase {
         emit AllTokensUnfrozen();
     }
 
-    function upgrade(address newImplementation, bytes calldata setupParams) external override onlyAdmin {
+    function upgrade(
+        address newImplementation,
+        bytes32 newImplementationCodeHash,
+        bytes calldata setupParams
+    ) external override onlyAdmin {
+        require(newImplementationCodeHash == newImplementation.codehash, 'INV_CODEHASH');
+
         emit Upgraded(newImplementation);
 
         // AUDIT: If `newImplementation.setup` performs `selfdestruct`, it will result in the loss of _this_ implementation (thereby losing the gateway)

--- a/src/AxelarGatewayMultisig.sol
+++ b/src/AxelarGatewayMultisig.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IAxelarGatewayMultisig } from './interfaces/IAxelarGatewayMultisig.sol';
 

--- a/src/AxelarGatewayProxy.sol
+++ b/src/AxelarGatewayProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { EternalStorage } from './EternalStorage.sol';
 

--- a/src/AxelarGatewayProxyMultisig.sol
+++ b/src/AxelarGatewayProxyMultisig.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IAxelarGateway } from './interfaces/IAxelarGateway.sol';
 

--- a/src/AxelarGatewayProxySinglesig.sol
+++ b/src/AxelarGatewayProxySinglesig.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IAxelarGateway } from './interfaces/IAxelarGateway.sol';
 

--- a/src/AxelarGatewaySinglesig.sol
+++ b/src/AxelarGatewaySinglesig.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IAxelarGatewaySinglesig } from './interfaces/IAxelarGatewaySinglesig.sol';
 

--- a/src/BurnableMintableCappedERC20.sol
+++ b/src/BurnableMintableCappedERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { MintableCappedERC20 } from './MintableCappedERC20.sol';
 import { DepositHandler } from './DepositHandler.sol';

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 /*
  * @dev Provides information about the current execution context, including the

--- a/src/DepositHandler.sol
+++ b/src/DepositHandler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 contract DepositHandler {
     function execute(address callee, bytes calldata data) external returns (bool success, bytes memory returnData) {

--- a/src/ECDSA.sol
+++ b/src/ECDSA.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 /**
  * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.

--- a/src/ERC20.sol
+++ b/src/ERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IERC20 } from './interfaces/IERC20.sol';
 

--- a/src/EternalStorage.sol
+++ b/src/EternalStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 /**
  * @title EternalStorage

--- a/src/MintableCappedERC20.sol
+++ b/src/MintableCappedERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { ERC20 } from './ERC20.sol';
 import { Ownable } from './Ownable.sol';

--- a/src/Ownable.sol
+++ b/src/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 abstract contract Ownable {
     address public owner;

--- a/src/interfaces/IAxelarGateway.sol
+++ b/src/interfaces/IAxelarGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 interface IAxelarGateway {
     /**********\
@@ -51,7 +51,11 @@ interface IAxelarGateway {
 
     function unfreezeAllTokens() external;
 
-    function upgrade(address newImplementation, bytes calldata setupParams) external;
+    function upgrade(
+        address newImplementation,
+        bytes32 newImplementationCodeHash,
+        bytes calldata setupParams
+    ) external;
 
     /**********************\
     |* External Functions *|

--- a/src/interfaces/IAxelarGatewayMultisig.sol
+++ b/src/interfaces/IAxelarGatewayMultisig.sol
@@ -1,17 +1,20 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IAxelarGateway } from './IAxelarGateway.sol';
 
 interface IAxelarGatewayMultisig is IAxelarGateway {
-
     event OwnershipTransferred(address[] preOwners, uint256 prevThreshold, address[] newOwners, uint256 newThreshold);
 
-    event OperatorshipTransferred(address[] preOperators, uint256 prevThreshold, address[] newOperators, uint256 newThreshold);
+    event OperatorshipTransferred(
+        address[] preOperators,
+        uint256 prevThreshold,
+        address[] newOperators,
+        uint256 newThreshold
+    );
 
     function owners() external view returns (address[] memory);
 
     function operators() external view returns (address[] memory);
-
 }

--- a/src/interfaces/IAxelarGatewaySinglesig.sol
+++ b/src/interfaces/IAxelarGatewaySinglesig.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 import { IAxelarGateway } from './IAxelarGateway.sol';
 
 interface IAxelarGatewaySinglesig is IAxelarGateway {
-
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     event OperatorshipTransferred(address indexed previousOperator, address indexed newOperator);
@@ -13,5 +12,4 @@ interface IAxelarGatewaySinglesig is IAxelarGateway {
     function owner() external view returns (address);
 
     function operator() external view returns (address);
-
 }

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.9;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.
@@ -59,7 +59,11 @@ interface IERC20 {
      *
      * Emits a {Transfer} event.
      */
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
 
     /**
      * @dev Emitted when `value` tokens are moved from one account (`from`) to

--- a/test/AxelarGatewayMultisig.js
+++ b/test/AxelarGatewayMultisig.js
@@ -81,6 +81,10 @@ describe('AxelarGatewayMultisig', () => {
         AxelarGatewayMultisig,
         [],
       );
+      const newImplementationCode = await newImplementation.provider.getCode(
+        newImplementation.address,
+      );
+      const newImplementationCodeHash = keccak256(newImplementationCode);
       const params = arrayify(
         defaultAbiCoder.encode(
           ['address[]', 'uint8', 'address[]', 'uint8', 'address[]', 'uint8'],
@@ -96,14 +100,24 @@ describe('AxelarGatewayMultisig', () => {
       );
 
       return expect(
-        contract.connect(admins[0]).upgrade(newImplementation.address, params),
+        contract
+          .connect(admins[0])
+          .upgrade(
+            newImplementation.address,
+            newImplementationCodeHash,
+            params,
+          ),
       )
         .to.not.emit(contract, 'Upgraded')
         .then(() =>
           expect(
             contract
               .connect(admins[2])
-              .upgrade(newImplementation.address, params),
+              .upgrade(
+                newImplementation.address,
+                newImplementationCodeHash,
+                params,
+              ),
           )
             .to.emit(contract, 'Upgraded')
             .withArgs(newImplementation.address),

--- a/test/AxelarGatewaySinglesig.js
+++ b/test/AxelarGatewaySinglesig.js
@@ -294,11 +294,14 @@ describe('AxelarGatewaySingleSig', () => {
   });
 
   describe('upgrade', () => {
-    it('should allow admins to upgrade implementation', async () => {
+    it('should not allow admins to upgrade to a wrong implementation', async () => {
       const newImplementation = await deployContract(
         ownerWallet,
         AxelarGatewaySinglesig,
         [],
+      );
+      const wrongImplementationCodeHash = keccak256(
+        `0x${AxelarGatewaySinglesig.bytecode}`,
       );
       const params = defaultAbiCoder.encode(
         ['address[]', 'uint8', 'address', 'address'],
@@ -313,21 +316,87 @@ describe('AxelarGatewaySingleSig', () => {
       return expect(
         contract
           .connect(adminWallet1)
-          .upgrade(newImplementation.address, params),
+          .upgrade(
+            newImplementation.address,
+            wrongImplementationCodeHash,
+            params,
+          ),
       )
         .to.not.emit(contract, 'Upgraded')
         .then(() =>
           expect(
             contract
               .connect(adminWallet2)
-              .upgrade(newImplementation.address, params),
+              .upgrade(
+                newImplementation.address,
+                wrongImplementationCodeHash,
+                params,
+              ),
           ).to.not.emit(contract, 'Upgraded'),
         )
         .then(() =>
           expect(
             contract
               .connect(adminWallet3)
-              .upgrade(newImplementation.address, params),
+              .upgrade(
+                newImplementation.address,
+                wrongImplementationCodeHash,
+                params,
+              ),
+          ).to.be.revertedWith('INV_CODEHASH'),
+        );
+    });
+
+    it('should allow admins to upgrade to the correct implementation', async () => {
+      const newImplementation = await deployContract(
+        ownerWallet,
+        AxelarGatewaySinglesig,
+        [],
+      );
+      const newImplementationCode = await newImplementation.provider.getCode(
+        newImplementation.address,
+      );
+      const newImplementationCodeHash = keccak256(newImplementationCode);
+      const params = defaultAbiCoder.encode(
+        ['address[]', 'uint8', 'address', 'address'],
+        [
+          [ownerWallet.address, operatorWallet.address],
+          1,
+          ownerWallet.address,
+          operatorWallet.address,
+        ],
+      );
+
+      return expect(
+        contract
+          .connect(adminWallet1)
+          .upgrade(
+            newImplementation.address,
+            newImplementationCodeHash,
+            params,
+          ),
+      )
+        .to.not.emit(contract, 'Upgraded')
+        .then(() =>
+          expect(
+            contract
+              .connect(adminWallet2)
+              .upgrade(
+                newImplementation.address,
+                newImplementationCodeHash,
+                params,
+              ),
+          ).to.not.emit(contract, 'Upgraded'),
+        )
+        .then(() =>
+          expect(
+            contract
+              .connect(adminWallet3)
+              .upgrade(
+                newImplementation.address,
+                newImplementationCodeHash,
+                params,
+              ),
           )
             .to.emit(contract, 'Upgraded')
             .withArgs(newImplementation.address),


### PR DESCRIPTION
1. Fix compiler version in pragma to be `0.8.9`
2. Change upgrade function signature to `function upgrade(address newImplementation, bytes32 newImplementationCodeHash, bytes calldata setupParams)` to make sure new implementation's codehash is as expected