### PR TITLE
feat: require sorted signatures from owners/operators to improve gas cost

### DIFF
--- a/src/AxelarGatewayMultisig.sol
+++ b/src/AxelarGatewayMultisig.sol
@@ -24,16 +24,14 @@ contract AxelarGatewayMultisig is IAxelarGatewayMultisig, AxelarGateway {
     bytes32 internal constant PREFIX_OPERATOR_THRESHOLD = keccak256('operator-threshold');
     bytes32 internal constant PREFIX_IS_OPERATOR = keccak256('is-operator');
 
-    function _containsDuplicates(address[] memory accounts) internal pure returns (bool) {
-        uint256 count = accounts.length;
-
-        for (uint256 i; i < count; ++i) {
-            for (uint256 j = i + 1; j < count; ++j) {
-                if (accounts[i] == accounts[j]) return true;
+    function _isSortedAscAndContainsNoDuplicate(address[] memory accounts) internal pure returns (bool) {
+        for (uint256 i; i < accounts.length - 1; ++i) {
+            if (accounts[i] >= accounts[i + 1]) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /************************\
@@ -426,7 +424,7 @@ contract AxelarGatewayMultisig is IAxelarGatewayMultisig, AxelarGateway {
         ) = abi.decode(data, (uint256, Role, bytes32[], string[], bytes[]));
 
         require(chainId == _getChainID(), 'INV_CHAIN');
-        require(!_containsDuplicates(signers), 'DUP_SIGNERS');
+        require(_isSortedAscAndContainsNoDuplicate(signers), 'DUP_SIGNERS');
 
         uint256 commandsLength = commandIds.length;
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,6 +3,7 @@
 const {
   utils: { defaultAbiCoder, id, arrayify, keccak256 },
 } = require('ethers');
+const { sortBy } = require('lodash');
 
 const getRandomInt = (max) => {
   return Math.floor(Math.random() * max);
@@ -20,7 +21,9 @@ module.exports = {
 
   getSignedMultisigExecuteInput: (data, wallets) =>
     Promise.all(
-      wallets.map((wallet) => wallet.signMessage(arrayify(keccak256(data)))),
+      sortBy(wallets, (wallet) => wallet.address.toLowerCase()).map((wallet) =>
+        wallet.signMessage(arrayify(keccak256(data))),
+      ),
     ).then((signatures) =>
       defaultAbiCoder.encode(['bytes', 'bytes[]'], [data, signatures]),
     ),


### PR DESCRIPTION
## Before for deployToken
```
ownerThreshold: 1, gasCost: 1160686
ownerThreshold: 2, gasCost: 1169661
ownerThreshold: 3, gasCost: 1178876
ownerThreshold: 4, gasCost: 1188325
ownerThreshold: 5, gasCost: 1198088
ownerThreshold: 6, gasCost: 1208143
ownerThreshold: 7, gasCost: 1218492
ownerThreshold: 8, gasCost: 1229095
ownerThreshold: 9, gasCost: 1240038
ownerThreshold: 10, gasCost: 1251108
ownerThreshold: 11, gasCost: 1262606
ownerThreshold: 12, gasCost: 1274233
ownerThreshold: 13, gasCost: 1286229
ownerThreshold: 14, gasCost: 1298476
ownerThreshold: 15, gasCost: 1311036
ownerThreshold: 16, gasCost: 1323795
ownerThreshold: 17, gasCost: 1336935
ownerThreshold: 18, gasCost: 1350349
ownerThreshold: 19, gasCost: 1363987
ownerThreshold: 20, gasCost: 1377873
ownerThreshold: 21, gasCost: 1392094
ownerThreshold: 22, gasCost: 1406512
ownerThreshold: 23, gasCost: 1421341
ownerThreshold: 24, gasCost: 1436141
ownerThreshold: 25, gasCost: 1451638
ownerThreshold: 26, gasCost: 1467283
ownerThreshold: 27, gasCost: 1483187
ownerThreshold: 28, gasCost: 1499091
ownerThreshold: 29, gasCost: 1515681
ownerThreshold: 30, gasCost: 1532481
ownerThreshold: 31, gasCost: 1549354
ownerThreshold: 32, gasCost: 1566414
ownerThreshold: 33, gasCost: 1584171
ownerThreshold: 34, gasCost: 1601864
ownerThreshold: 35, gasCost: 1620036
ownerThreshold: 36, gasCost: 1638144
ownerThreshold: 37, gasCost: 1657036
ownerThreshold: 38, gasCost: 1676038
ownerThreshold: 39, gasCost: 1695143
ownerThreshold: 40, gasCost: 1714200
ownerThreshold: 41, gasCost: 1734324
ownerThreshold: 42, gasCost: 1754457
ownerThreshold: 43, gasCost: 1774689
ownerThreshold: 44, gasCost: 1794907
ownerThreshold: 45, gasCost: 1816032
ownerThreshold: 46, gasCost: 1837247
ownerThreshold: 47, gasCost: 1858634
ownerThreshold: 48, gasCost: 1879996
ownerThreshold: 49, gasCost: 1902274
ownerThreshold: 50, gasCost: 1924593
```

## After for deployToken
```
ownerThreshold: 1, gasCost: 1160523
ownerThreshold: 2, gasCost: 1169386
ownerThreshold: 3, gasCost: 1178242
ownerThreshold: 4, gasCost: 1187094
ownerThreshold: 5, gasCost: 1195970
ownerThreshold: 6, gasCost: 1204844
ownerThreshold: 7, gasCost: 1213720
ownerThreshold: 8, gasCost: 1222471
ownerThreshold: 9, gasCost: 1231466
ownerThreshold: 10, gasCost: 1240221
ownerThreshold: 11, gasCost: 1249113
ownerThreshold: 12, gasCost: 1257928
ownerThreshold: 13, gasCost: 1266807
ownerThreshold: 14, gasCost: 1275691
ownerThreshold: 15, gasCost: 1284662
ownerThreshold: 16, gasCost: 1293382
ownerThreshold: 17, gasCost: 1302340
ownerThreshold: 18, gasCost: 1311256
ownerThreshold: 19, gasCost: 1320097
ownerThreshold: 20, gasCost: 1328774
ownerThreshold: 21, gasCost: 1337777
ownerThreshold: 22, gasCost: 1346684
ownerThreshold: 23, gasCost: 1355591
ownerThreshold: 24, gasCost: 1364381
ownerThreshold: 25, gasCost: 1373231
ownerThreshold: 26, gasCost: 1382165
ownerThreshold: 27, gasCost: 1390985
ownerThreshold: 28, gasCost: 1399728
ownerThreshold: 29, gasCost: 1408726
ownerThreshold: 30, gasCost: 1417563
ownerThreshold: 31, gasCost: 1426552
ownerThreshold: 32, gasCost: 1435322
ownerThreshold: 33, gasCost: 1444054
ownerThreshold: 34, gasCost: 1453173
ownerThreshold: 35, gasCost: 1461969
ownerThreshold: 36, gasCost: 1470697
ownerThreshold: 37, gasCost: 1479807
ownerThreshold: 38, gasCost: 1488662
ownerThreshold: 39, gasCost: 1497453
ownerThreshold: 40, gasCost: 1506263
ownerThreshold: 41, gasCost: 1515333
ownerThreshold: 42, gasCost: 1524141
ownerThreshold: 43, gasCost: 1533165
ownerThreshold: 44, gasCost: 1541723
ownerThreshold: 45, gasCost: 1550878
ownerThreshold: 46, gasCost: 1559718
ownerThreshold: 47, gasCost: 1568667
ownerThreshold: 48, gasCost: 1577296
ownerThreshold: 49, gasCost: 1586462
ownerThreshold: 50, gasCost: 1595377
```